### PR TITLE
Added dash-bootstrap-components requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 html2text
 pandas
+dash-bootstrap-components


### PR DESCRIPTION
Added Dash Bootstrap Components in the `requirements.txt` file as it is used in [`app.py`](https://github.com/PeskyPotato/mastodon_archive_reader/blob/dash-requirements/app.py#L1) but was previously not included as a requirement.